### PR TITLE
Header files to make C functions callable by other packages

### DIFF
--- a/inst/include/cubature.h
+++ b/inst/include/cubature.h
@@ -1,0 +1,94 @@
+#ifndef __cubature_h__
+#define __cubature_h__
+
+#include <R.h>
+#include <Rinternals.h>
+#include "cubature_typedefs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  /* adapative integration by partitioning the integration domain ("h-adaptive")
+     and using the same fixed-degree quadrature in each subdomain, recursively,
+     until convergence is achieved. */
+  int hcubature(unsigned fdim, integrand f, void *fdata,
+                unsigned dim, const double *xmin, const double *xmax, 
+                size_t maxEval, double reqAbsError, double reqRelError, 
+                error_norm norm,
+                double *val, double *err) {
+    typedef int (*Fun)(unsigned, integrand, void*, unsigned, const double*,
+                 const double*, size_t, double, double, error_norm,
+                 double*, double*);
+    static Fun fun = NULL;
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("cubature")) ),
+                       R_GlobalEnv);
+      fun = (Fun) R_GetCCallable("cubature", "hcubature"); 
+    }
+    return fun(fdim,f,fdata,dim,xmin,xmax,maxEval,reqAbsError,reqRelError,norm,val,err); 
+  }
+  
+  /* as hcubature, but vectorized integrand */
+  int hcubature_v(unsigned fdim, integrand_v f, void *fdata,
+                  unsigned dim, const double *xmin, const double *xmax, 
+                  size_t maxEval, double reqAbsError, double reqRelError, 
+                  error_norm norm, double *val, double *err) {
+    typedef int (*Fun)(unsigned, integrand_v, void*, unsigned, const double*,
+                 const double*, size_t, double, double, error_norm,
+                 double*, double*);
+    static Fun fun = NULL;
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("cubature")) ),
+                       R_GlobalEnv);
+      fun = (Fun) R_GetCCallable("cubature", "hcubature_v");
+    }
+    return fun(fdim,f,fdata,dim,xmin,xmax,maxEval,reqAbsError,reqRelError,norm,val,err); 
+  }
+  
+  /* adaptive integration by increasing the degree of (tensor-product
+     Clenshaw-Curtis) quadrature rules ("p-adaptive"), rather than
+     subdividing the domain ("h-adaptive").  Possibly better for
+     smooth integrands in low dimensions. */
+  int pcubature(unsigned fdim, integrand f, void *fdata,
+                unsigned dim, const double *xmin, const double *xmax, 
+                size_t maxEval, double reqAbsError, double reqRelError, 
+                error_norm norm, double *val, double *err) {
+    typedef int (*Fun)(unsigned, integrand, void*, unsigned, const double*,
+                 const double*, size_t, double, double, error_norm,
+                 double*, double*);
+    static Fun fun = NULL;
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("cubature")) ),
+                       R_GlobalEnv);
+      fun = (Fun) R_GetCCallable("cubature", "pcubature");
+    }
+    return fun(fdim,f,fdata,dim,xmin,xmax,maxEval,reqAbsError,reqRelError,norm,val,err); 
+  }
+  
+  /* as pcubature, but vectorized integrand */
+  int pcubature_v(unsigned fdim, integrand_v f, void *fdata,
+                  unsigned dim, const double *xmin, const double *xmax, 
+                  size_t maxEval, double reqAbsError, double reqRelError, 
+                  error_norm norm, double *val, double *err) {
+    typedef int (*Fun)(unsigned, integrand_v, void*, unsigned, const double*,
+                 const double*, size_t, double, double, error_norm,
+                 double*, double*);
+    static Fun fun = NULL;
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("cubature")) ),
+                       R_GlobalEnv);
+      fun = (Fun) R_GetCCallable("cubature", "pcubature_v");
+    }
+    return fun(fdim,f,fdata,dim,xmin,xmax,maxEval,reqAbsError,reqRelError,norm,val,err); 
+  }
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/inst/include/cubature_typedefs.h
+++ b/inst/include/cubature_typedefs.h
@@ -1,0 +1,45 @@
+#ifndef __cubature_typedefs_h__
+#define __cubature_typedefs_h__
+
+/* separate h file for the types and the error_norm enum,
+ to avoid duplicate symbol error. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+  /* a vector integrand - evaluates the function at the given point x
+   (an array of length ndim) and returns the result in fval (an array
+  of length fdim).   The void* parameter is there in case you have
+  to pass any additional data through to your function (it corresponds
+  to the fdata parameter you pass to cubature).  Return 0 on
+  success or nonzero to terminate the integration. */
+  typedef int (*integrand) (unsigned ndim, const double *x, void *,
+               unsigned fdim, double *fval);
+  
+  /* a vector integrand of a vector of npt points: x[i*ndim + j] is the
+  j-th coordinate of the i-th point, and the k-th function evaluation
+  for the i-th point is returned in fval[i*fdim + k].  Return 0 on success
+  or nonzero to terminate the integration. */
+  typedef int (*integrand_v) (unsigned ndim, size_t npt,
+               const double *x, void *,
+               unsigned fdim, double *fval);
+  
+  /* Different ways of measuring the absolute and relative error when
+  we have multiple integrands, given a vector e of error estimates
+  in the individual components of a vector v of integrands.  These
+  are all equivalent when there is only a single integrand. */
+  typedef enum {
+  ERROR_INDIVIDUAL = 0, /* individual relerr criteria in each component */
+  ERROR_PAIRED, /* paired L2 norms of errors in each component,
+    mainly for integrating vectors of complex numbers */
+  ERROR_L2, /* abserr is L_2 norm |e|, and relerr is |e|/|v| */
+  ERROR_L1, /* abserr is L_1 norm |e|, and relerr is |e|/|v| */
+  ERROR_LINF /* abserr is L_\infty norm |e|, and relerr is |e|/|v| */
+               } error_norm;
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/cubature_init.c
+++ b/src/cubature_init.c
@@ -1,6 +1,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
+#include "cubature.h"
 
 
 /* .Call entry points */
@@ -19,4 +20,10 @@ static const R_CallMethodDef CallEntries[] = {
 void R_init_cubature(DllInfo *dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
+  R_RegisterCCallable("cubature", "adapt_integrate", (DL_FUNC) hcubature);
+  R_RegisterCCallable("cubature", "adapt_integrate_v", (DL_FUNC) hcubature_v);
+  R_RegisterCCallable("cubature", "hcubature", (DL_FUNC) hcubature);
+  R_RegisterCCallable("cubature", "hcubature_v", (DL_FUNC) hcubature_v);
+  R_RegisterCCallable("cubature", "pcubature", (DL_FUNC) pcubature);
+  R_RegisterCCallable("cubature", "pcubature_v", (DL_FUNC) pcubature_v);
 }

--- a/vignettes/cubature.Rmd
+++ b/vignettes/cubature.Rmd
@@ -106,7 +106,7 @@ harness <- function(which = NULL,
     if (is.null(which)) {
         fnIndices <- seq_along(fns)
     } else {
-        fnIndices <- match(which, names(fns))
+        fnIndices <- na.omit(match(which, names(fns)))
     }
     fnList <- lapply(names(fns)[fnIndices], function(x) call(x))
 


### PR DESCRIPTION
Hi Naras,

These changes make it very easy to directly call hcubature, hcubature_v, pcubature and pcubature_v from C code in other packages.

I've checked the changes and everything appears to work fine. R CMD check is happy with the changes on my machine and the win builder service check was also successful.

I didn't have R2Cuba installed on my machine at first and this caused a problem with building the vignette. So I've made a small change there as well.

Best,
Manuel