### PR TITLE
Made return value functionEvaluations consistent with maxEval

### DIFF
--- a/src/Rcpp-cubature.cpp
+++ b/src/Rcpp-cubature.cpp
@@ -43,7 +43,7 @@ int fWrapper_v(unsigned ndim, size_t npts, const double *x, void *fdata,
     for (unsigned i = 0; i < fdim * npts; ++i) {
         fval[i] = fxp[i];
     }
-    (iip -> count)++;
+    (iip -> count)+=npts;
     return 0;
 }
 


### PR DESCRIPTION
Dear Mr. Narasimhan,

in the attached pull request, I changed the way the number of function evaluations is counted in the evaluation wrapper for vectorized functions.

This counter should now be consistent with the number of functions evaluations "numEval" which is used in the underlying cubature C code.
Before, calling a vectorized function with a large vector was counted as a single function evaluation, leading to situations where sometimes the cubature algorithm would terminate because the "maxEval" threshold was crossed, but the return value functionEvaluations was nowhere near the specified boundary.

Thank you for taking the time to consider this merge request, your package is very helpful for my work.

Best regards,
Jan Meis