### PR TITLE
Enable cross compilation

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -19,7 +19,7 @@ cubature.ts:
 
 cuba.ts:
 	((cd $(CUBA_DIR) && \
-	./configure && \
+	./configure $(R_CONFIGURE_FLAGS) && \
 	$(MAKE) libcuba.a AR="$(AR)" ARFLAGS="-rv" RANLIB="$(RANLIB)" CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(PKG_CFLAGS)") && \
 	touch $@)
 


### PR DESCRIPTION
This allows us to pass `--host=...` flags to the configure script, which is needed for cross compilation.

See build log here: https://github.com/r-universe/bnaras/actions/runs/7494394414/job/20402366488

