### PR TITLE
Updated Cuba and made CRAN fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cubature
 Type: Package
 Title: Adaptive Multivariate Integration over Hypercubes
-Version: 2.1.1
+Version: 2.1.2
 VignetteBuilder: knitr
 SystemRequirements: GNU make and USE_C17
 URL: https://bnaras.github.io/cubature/

--- a/src/Cuba-win/Makefile
+++ b/src/Cuba-win/Makefile
@@ -18,6 +18,7 @@ COMMON_CDEPS = $(COMMON_DEPS) $(common)/CSample.c $(common)/Parallel.c $(common)
 COMMON_TMDEPS = $(COMMON_DEPS) $(common)/MSample.c
 
 RNG_DEPS = $(common)/Random.c $(common)/KorobovCoeff.c
+R_DEPS = $(LIB)(r_helpers.o)
 
 VEGAS_C = $(vegas)/Vegas.c
 VEGAS_TM = $(vegas)/Vegas.tm
@@ -26,8 +27,8 @@ VEGAS_DEPS = $(RNG_DEPS) \
   $(vegas)/Grid.c $(vegas)/Integrate.c
 VEGAS = $(VEGAS_C) $(VEGAS_TM) $(VEGAS_DEPS)
 
-$(LIB)(Vegas.o): config.h $(VEGAS_C) $(VEGAS_DEPS) $(COMMON_CDEPS) 
-	$(CC) $(CFLAGS) -I$(vegas) -DNOUNDERSCORE -c -o Vegas.o $(VEGAS_C)
+$(LIB)(Vegas.o): config.h $(VEGAS_C) $(VEGAS_DEPS) $(COMMON_CDEPS) $(R_DEPS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(vegas) -DNOUNDERSCORE -c -o Vegas.o $(VEGAS_C)
 	$(AR) $(ARFLAGS) $(LIB) Vegas.o
 	$(RM) Vegas.o
 
@@ -41,8 +42,8 @@ SUAVE_DEPS = $(RNG_DEPS) \
   $(suave)/Integrate.c
 SUAVE = $(SUAVE_C) $(SUAVE_TM) $(SUAVE_DEPS)
 
-$(LIB)(Suave.o): config.h $(SUAVE_C) $(SUAVE_DEPS) $(COMMON_CDEPS)
-	$(CC) $(CFLAGS) -I$(suave) -DNOUNDERSCORE -c -o Suave.o $(SUAVE_C)
+$(LIB)(Suave.o): config.h $(SUAVE_C) $(SUAVE_DEPS) $(COMMON_CDEPS) $(R_DEPS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(suave) -DNOUNDERSCORE -c -o Suave.o $(SUAVE_C)
 	$(AR) $(ARFLAGS) $(LIB) Suave.o
 	$(RM) Suave.o
 
@@ -57,8 +58,8 @@ DIVONNE_DEPS = $(RNG_DEPS) \
   $(divonne)/Split.c $(divonne)/Integrate.c
 DIVONNE = $(DIVONNE_C) $(DIVONNE_TM) $(DIVONNE_DEPS)
 
-$(LIB)(Divonne.o): config.h $(DIVONNE_C) $(DIVONNE_DEPS) $(COMMON_CDEPS)
-	$(CC) $(CFLAGS) -I$(divonne) -DNOUNDERSCORE -c -o Divonne.o $(DIVONNE_C)
+$(LIB)(Divonne.o): config.h $(DIVONNE_C) $(DIVONNE_DEPS) $(COMMON_CDEPS) $(R_DEPS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(divonne) -DNOUNDERSCORE -c -o Divonne.o $(DIVONNE_C)
 	$(AR) $(ARFLAGS) $(LIB) Divonne.o
 	$(RM) Divonne.o
 
@@ -71,29 +72,32 @@ CUHRE_DEPS = \
   $(cuhre)/Rule.c $(cuhre)/Integrate.c
 CUHRE = $(CUHRE_C) $(CUHRE_TM) $(CUHRE_DEPS)
 
-$(LIB)(Cuhre.o): config.h $(CUHRE_C) $(CUHRE_DEPS) $(COMMON_CDEPS)
-	$(CC) $(CFLAGS) -I$(cuhre) -DNOUNDERSCORE -c -o Cuhre.o $(CUHRE_C)
+$(LIB)(Cuhre.o): config.h $(CUHRE_C) $(CUHRE_DEPS) $(COMMON_CDEPS) $(R_DEPS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(cuhre) -DNOUNDERSCORE -c -o Cuhre.o $(CUHRE_C)
 	$(AR) $(ARFLAGS) $(LIB) Cuhre.o
 	$(RM) Cuhre.o
 
-
+$(LIB)(r_helpers.o): $(common)/r_helpers.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DNOUNDERSCORE -c -o r_helpers.o $(common)/r_helpers.c
+	$(AR) $(ARFLAGS) $(LIB) r_helpers.o
+	$(RM) r_helpers.o
 
 $(LIB)(Fork.o): $(common)/Fork.c $(common)/stddecl.h $(common)/sock.h
-	$(CC) $(CFLAGS) -DNOUNDERSCORE -c -o Fork.o $(common)/Fork.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DNOUNDERSCORE -c -o Fork.o $(common)/Fork.c
 	$(AR) $(ARFLAGS) $(LIB) Fork.o
 	$(RM) Fork.o
 
 
 
 $(LIB)(Global.o): $(common)/Global.c $(common)/stddecl.h
-	$(CC) $(CFLAGS) -DNOUNDERSCORE -c -o Global.o $(common)/Global.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DNOUNDERSCORE -c -o Global.o $(common)/Global.c
 	$(AR) $(ARFLAGS) $(LIB) Global.o
 	$(RM) Global.o
 
 
 
 $(LIB)(Data.o): $(common)/Data.c $(common)/stddecl.h
-	$(CC) $(CFLAGS) -c -o Data.o $(common)/Data.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o Data.o $(common)/Data.c
 	$(AR) $(ARFLAGS) $(LIB) Data.o
 	$(RM) Data.o
 
@@ -103,6 +107,7 @@ $(LIB): $(LIB)(Vegas.o)     \
 	$(LIB)(Cuhre.o)     \
 	$(LIB)(Fork.o)      \
 	$(LIB)(Global.o)    \
+	$(LIB)(r_helpers.o) \
 	$(LIB)(Data.o)
 	-$(RANLIB) $(LIB)
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,8 +1,8 @@
 CUBATURE_DIR=cubature-1.0.4
 CUBA_DIR=Cuba
 
-PKG_CFLAGS=-I. -I../inst/include -I./src/common
-PKG_CPPFLAGS=$(PKG_CFLAGS)
+R_CPPFLAGS := $(shell $(R_HOME)/bin/R CMD config --cppflags)
+PKG_CPPFLAGS=-I. -I../inst/include -I../../inst/include -I./src/common -D_R_INTERFACE $(R_CPPFLAGS)
 PKG_LIBS=-L./$(CUBATURE_DIR) -L./$(CUBA_DIR) -lcubature -lcuba
 
 $(SHLIB): Rcpp-cubature.o Rcpp-Cuba.o RcppExports.o cubature_init.o
@@ -13,13 +13,13 @@ Rcpp-Cuba.o: cuba.ts
 
 cubature.ts:
 	((cd $(CUBATURE_DIR) && \
-	($(MAKE) libcubature.a CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(PKG_CFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)")) && \
+	($(MAKE) libcubature.a CC="$(CC)" CFLAGS="$(CPPFLAGS) $(PKG_CPPFLAGS) $(CFLAGS) $(CPICFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)")) && \
 	touch $@)
 
 cuba.ts:
 	((cd $(CUBA_DIR) && \
 	./configure $(R_CONFIGURE_FLAGS) && \
-	$(MAKE) libcuba.a AR="$(AR)" ARFLAGS="-rv" RANLIB="$(RANLIB)" CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(PKG_CFLAGS)") && \
+	$(MAKE) libcuba.a CC="$(CC)" CFLAGS="$(CPPFLAGS) $(PKG_CPPFLAGS) $(CFLAGS) $(CPICFLAGS)" AR="$(AR)" ARFLAGS="-rv" RANLIB="$(RANLIB)") && \
 	touch $@)
 
 clean:

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,8 +2,8 @@ CUBATURE_DIR=cubature-1.0.4
 CUBA_DIR=Cuba
 CUBA_DIR_WIN=Cuba-win
 
-PKG_CFLAGS=-I. -I../inst/include
-PKG_CPPFLAGS=$(PKG_CFLAGS)
+R_CPPFLAGS := $(shell $(R_HOME)/bin/R CMD config --cppflags)
+PKG_CPPFLAGS=-I. -I../inst/include -I../../inst/include -I./src/common -D_R_INTERFACE $(R_CPPFLAGS)
 PKG_LIBS=-L./$(CUBATURE_DIR) -L./$(CUBA_DIR) -lcubature -lcuba
 
 $(SHLIB): Rcpp-cubature.o Rcpp-cuba.o RcppExports.o
@@ -13,13 +13,13 @@ RcppExports.o: cubature.ts
 Rcpp-Cuba.o: cuba.ts
 
 cubature.ts:
-	cd $(CUBATURE_DIR) && $(MAKE) libcubature.a CC=$(CC) CFLAGS="$(CFLAGS) $(CPICFLAGS) $(PKG_CFLAGS) -DNOSHORTS" AR=$(AR) RANLIB=$(RANLIB)
+	cd $(CUBATURE_DIR) && $(MAKE) libcubature.a CC=$(CC) CFLAGS="$(CPPFLAGS) $(PKG_CPPFLAGS) $(CPICFLAGS)  -DNOSHORTS" AR=$(AR) RANLIB=$(RANLIB)
 	touch $@
 
 cuba.ts:
 	cp $(CUBA_DIR_WIN)/config.h $(CUBA_DIR)/config.h
 	cp $(CUBA_DIR_WIN)/Makefile $(CUBA_DIR)/Makefile
-	cd $(CUBA_DIR) && $(MAKE) lib CC=$(CC) CFLAGS="$(CFLAGS) -UHAVE_FORK -DHAVE_CONFIG_H -DREALSIZE=8 $(CPICFLAGS) -I./src/common $(PKG_CFLAGS)" AR=$(AR) RANLIB=$(RANLIB) 
+	cd $(CUBA_DIR) && $(MAKE) lib CC=$(CC) CFLAGS="$(CPPFLAGS) $(PKG_CPPFLAGS) -UHAVE_FORK -DHAVE_CONFIG_H -DREALSIZE=8 $(CPICFLAGS)" AR=$(AR) RANLIB=$(RANLIB) 
 	touch $@
 
 clean:

--- a/src/cubature-1.0.4/hcubature.c
+++ b/src/cubature-1.0.4/hcubature.c
@@ -26,6 +26,10 @@
  *
  */
 
+#ifdef _R_INTERFACE
+#include <R.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -867,8 +871,12 @@ static heap_item heap_pop(heap *h)
      int i, n, child;
 
      if (!(h->n)) {
+#ifdef _R_INTERFACE
+       Rf_error("hcubature.c: attempted to pop an empty heap\n");
+#else
 	  fprintf(stderr, "attempted to pop an empty heap\n");
 	  exit(EXIT_FAILURE);
+#endif
      }
 
      ret = h->items[0];


### PR DESCRIPTION
CRAN fixes to avoid use of `exit()`, `sprintf()`, `abort()` etc. in the underlying C/C++ libraries.